### PR TITLE
Add type exports support in package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.7 (2023-10-26)
+
+### Internal updates
+
+Add support for ESM/bundler module resolution in TypeScript
+
 ## 1.1.6 (2023-05-26)
 
 ### Bug fixes

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.cjs",
   "type": "module",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lezer/highlight",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Highlighting system for Lezer parse trees",
   "main": "dist/index.cjs",
   "type": "module",


### PR DESCRIPTION
Adds the proper value in `package.exports` for TypeScript to pick the type declarations.