### PR TITLE
highlight crashes upon trying to iterate over a list of tags, "undefined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lezer/highlight",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Highlighting system for Lezer parse trees",
   "main": "dist/index.cjs",
   "type": "module",

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -241,6 +241,8 @@ export function tagHighlighter(tags: readonly {tag: Tag | readonly Tag[], class:
   return {
     style: (tags) => {
       let cls = all
+      if (tags === undefined)
+	  return cls
       for (let tag of tags) {
         for (let sub of tag.set) {
           let tagClass = map[sub.id]


### PR DESCRIPTION
While using this great plugin for codemirror, I encountered a case where tags is being assigned "undefined".  This results in the plugin crashing our editor. I was hoping we could get this fix pushed in for the next release. Please let me know if you think I'm missing anything that may result in this error. However, it still might be wise to account for "undefined" before iterating through the expected list. Thanks for all your contributions and we get a lot of great use out of your tools!!

![image](https://github.com/lezer-parser/highlight/assets/1440489/c2948eb1-a0c5-44bf-8301-144b93795811)
